### PR TITLE
Shibboleth administration guide

### DIFF
--- a/shibboleth-administration.md
+++ b/shibboleth-administration.md
@@ -10,7 +10,7 @@ this guide, you will be able to:
   - Configure a connection to a LDAP backend
   - Define attributes based on LDAP directory
   - Release attributes to SP
-- Test attribute configuration from the command line
+- Troubleshoot attribute definitions
 
 ## Install Shibboleth idP
 
@@ -130,6 +130,43 @@ three common definitions.
 
 https://wiki.shibboleth.net/confluence/display/SHIB2/IdPAddAttribute#IdPAddAttribute-3.ReleasetheAttribute
 
-## Test attribute configuration from the command line
+```xml
+<!-- Release attributes to anyone -->
+<afp:AttributeFilterPolicy id="releaseEverythingToAnyone">
+  <afp:PolicyRequirementRule xsi:type="basic:ANY"/>
+  <afp:AttributeRule attributeID="NameID">
+    <afp:PermitValueRule xsi:type="basic:ANY"/>
+  </afp:AttributeRule>
+  <afp:AttributeRule attributeID="emails">
+    <afp:PermitValueRule xsi:type="basic:ANY" />
+  </afp:AttributeRule>
+  <afp:AttributeRule attributeID="administrator">
+    <afp:PermitValueRule xsi:type="basic:ANY" />
+  </afp:AttributeRule>
+</afp:AttributeFilterPolicy>
+```
 
-https://wiki.shibboleth.net/confluence/display/SHIB2/AACLI
+## Troubleshoot attribute definitions
+
+Use the [Attribute Authority, Command Line Interface
+(AACLI)](https://wiki.shibboleth.net/confluence/display/SHIB2/AACLI) to test
+whether attributes are properly configured.
+
+```sh
+$ bin/aacli.sh --configDir ./conf --principal admin1
+
+<?xml version="1.0" encoding="UTF-8"?><saml2:AttributeStatement xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">
+  <saml2:Attribute FriendlyName="administrator" Name="administrator" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+    <saml2:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xs:string">true</saml2:AttributeValue>
+  </saml2:Attribute>
+  <saml2:Attribute FriendlyName="emails" Name="emails" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+    <saml2:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xs:string">admin1@openldap.ghe.local</saml2:AttributeValue>
+  </saml2:Attribute>
+</saml2:AttributeStatement>
+```
+
+Look at the [idP
+logs](https://wiki.shibboleth.net/confluence/display/SHIB2/IdPLogging) for
+syntax errors, connection errors to data connectors, whether attributes are
+being filtered out by attribute filter policies. `idp-process.log` is the most
+useful.

--- a/shibboleth-administration.md
+++ b/shibboleth-administration.md
@@ -22,6 +22,11 @@ tar xf shibboleth-identityprovider-2.4.2-bin.tar.gz
 cd shibboleth-identityprovider-2.4.2
 sudo ./install.sh
 ```
+
+## Define a new SP
+
+https://wiki.shibboleth.net/confluence/display/SHIB2/IdPMetadataProvider
+
 ## Add attributes
 
 https://wiki.shibboleth.net/confluence/display/SHIB2/IdPAddAttribute

--- a/shibboleth-administration.md
+++ b/shibboleth-administration.md
@@ -65,6 +65,7 @@ There are many different `AttributeDefinition` types; Below is an example of
 three common definitions.
 
 ```xml
+<!-- conf/attribute-resolver.xml -->
 <!--
   Simple attribute definition:
     https://wiki.shibboleth.net/confluence/display/SHIB2/ResolverSimpleAttributeDefinition
@@ -131,6 +132,7 @@ three common definitions.
 https://wiki.shibboleth.net/confluence/display/SHIB2/IdPAddAttribute#IdPAddAttribute-3.ReleasetheAttribute
 
 ```xml
+<!-- conf/attribute-filter.xml -->
 <!-- Release attributes to anyone -->
 <afp:AttributeFilterPolicy id="releaseEverythingToAnyone">
   <afp:PolicyRequirementRule xsi:type="basic:ANY"/>

--- a/shibboleth-administration.md
+++ b/shibboleth-administration.md
@@ -16,6 +16,12 @@ this guide, you will be able to:
 
 https://wiki.shibboleth.net/confluence/display/SHIB2/IdPInstall
 
+```sh
+wget --no-verbose http://shibboleth.net/downloads/identity-provider/2.4.2/shibboleth-identityprovider-2.4.2-bin.tar.gz
+tar xf shibboleth-identityprovider-2.4.2-bin.tar.gz
+cd shibboleth-identityprovider-2.4.2
+sudo ./install.sh
+```
 ## Add attributes
 
 https://wiki.shibboleth.net/confluence/display/SHIB2/IdPAddAttribute

--- a/shibboleth-administration.md
+++ b/shibboleth-administration.md
@@ -23,6 +23,9 @@ cd shibboleth-identityprovider-2.4.2
 sudo ./install.sh
 ```
 
+This directory will be the root of your shibboleth install. Configuration files
+will live under the `conf` directory by default.
+
 ## Define a new SP
 
 https://wiki.shibboleth.net/confluence/display/SHIB2/IdPMetadataProvider

--- a/shibboleth-administration.md
+++ b/shibboleth-administration.md
@@ -128,7 +128,7 @@ three common definitions.
 
 ### Release attributes to SP
 
-https://wiki.shibboleth.net/confluence/display/SHIB2/IdPAddAttributeFilter
+https://wiki.shibboleth.net/confluence/display/SHIB2/IdPAddAttribute#IdPAddAttribute-3.ReleasetheAttribute
 
 ## Test attribute configuration from the command line
 

--- a/shibboleth-administration.md
+++ b/shibboleth-administration.md
@@ -1,0 +1,43 @@
+# Shibboleth Administration
+
+This is an introduction to installing and configuring Shibboleth identity
+provider (idP) for single sign-on with a service provider (SP). After reading
+this guide, you will be able to:
+
+- Install Shibboleth idP
+- Define a new SP
+- Add attributes
+  - Configure a connection to a LDAP backend
+  - Define attributes based on LDAP directory
+  - Release attributes to SP
+- Test attribute configuration from the command line
+
+## Install Shibboleth idP
+
+https://wiki.shibboleth.net/confluence/display/SHIB2/IdPInstall
+
+## Add attributes
+
+https://wiki.shibboleth.net/confluence/display/SHIB2/IdPAddAttribute
+
+### Configure a connection to a LDAP backend
+
+https://wiki.shibboleth.net/confluence/display/SHIB2/ResolverLDAPDataConnector
+
+### Define attributes based on LDAP directory
+
+https://wiki.shibboleth.net/confluence/display/SHIB2/IdPAddAttribute#IdPAddAttribute-AttributeDefinition
+
+https://wiki.shibboleth.net/confluence/display/SHIB2/ResolverSAML2NameIDAttributeDefinition
+https://wiki.shibboleth.net/confluence/display/SHIB2/ResolverSimpleAttributeDefinition
+https://wiki.shibboleth.net/confluence/display/SHIB2/ResolverMappedAttributeDefinition
+
+https://wiki.shibboleth.net/confluence/display/SHIB2/IdPAddAttribute#IdPAddAttribute-AttributeEncoding
+
+### Release attributes to SP
+
+https://wiki.shibboleth.net/confluence/display/SHIB2/IdPAddAttributeFilter
+
+## Test attribute configuration from the command line
+
+https://wiki.shibboleth.net/confluence/display/SHIB2/AACLI

--- a/shibboleth-administration.md
+++ b/shibboleth-administration.md
@@ -31,6 +31,16 @@ https://wiki.shibboleth.net/confluence/display/SHIB2/IdPMetadataProvider
 
 https://wiki.shibboleth.net/confluence/display/SHIB2/IdPAddAttribute
 
+In SAML, the user being single signed-on is called the **principal**.
+Information about the principal is defined via Shibboleth idP **attributes**.
+For example, common attributes may include full names, emails, departments,
+phone numbers. An attribute is defined by the following:
+
+- **Data connector**: Connectors define where the raw information about principals are retrieved from. e.g. relational database, LDAP.
+- **Attribute definition**: Definitions give an attribute an ID for reference, and define optional data transformations.
+- **Attribute encoding**: Within a definition, this specifies how the value of an attribute should be encoded.
+- **Attribute filter policy**: This defines who (SP's) can access attributes, and under what conditions.
+
 ### Configure a connection to a LDAP backend
 
 https://wiki.shibboleth.net/confluence/display/SHIB2/ResolverLDAPDataConnector

--- a/shibboleth-administration.md
+++ b/shibboleth-administration.md
@@ -45,6 +45,18 @@ phone numbers. An attribute is defined by the following:
 
 https://wiki.shibboleth.net/confluence/display/SHIB2/ResolverLDAPDataConnector
 
+```xml
+<!-- conf/attribute-resolver.xml -->
+<resolver:DataConnector xsi:type="LDAPDirectory" xmlns="urn:mace:shibboleth:2.0:resolver:dc"
+  id="myLDAP"
+  ldapURL="LDAP_URL"
+  baseDN="BASE_DN"
+  principal="LDAP_ADMIN_DN"
+  principalCredential="LDAP_ADMIN_PASSWORD"
+  lowercaseAttributeNames="true">
+</resolver:DataConnector>
+```
+
 ### Define attributes based on LDAP directory
 
 https://wiki.shibboleth.net/confluence/display/SHIB2/IdPAddAttribute#IdPAddAttribute-AttributeDefinition


### PR DESCRIPTION
This is a draft article for explaining a basic shibboleth identity provider install and configuration.

**edit**: [Rendered](https://github.com/jch/saml/blob/shibboleth-administration/shibboleth-administration.md)

cc @michaeltwofish @mtodd @sbryant @lildude