### PR TITLE
Clarify the principal's role in Response POST

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,9 +191,9 @@ the assertions about Alice:
 </samlp:Response>
 ```
 
-Again, this response is Base64 encoded, but since we're specified in our
+Again, this response is Base64 encoded. Since we've specified in our
 metadata to use HTTP Post binding for receiving messages, the identity provider
-will POST the encoded message back to
+will direct the principal to POST the encoded message back to
 `https://flights.acme-corp.biz/saml/consume`. The location was also defined in the
 metadata.
 


### PR DESCRIPTION
With HTTP POST binding, the Response is POSTed by the principal's browser via an HTML form. The current wording implies that the IdP is POSTing directly to the SP. This PR clarifies the language to note the principal's role.

cc @jch 